### PR TITLE
check all the keys for prototype pollution

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,6 +21,7 @@ function recursivelySetIn (object, path, value, index) {
   object = object || {}
 
   var key = path[index]
+  assert.ok(!POLLUTED_KEYS.includes(key), `recursivelySetIn: ${key} is disallowed in path due to possible prototype pollution attack.`)
 
   if (key === '-') {
     assert.ok(Array.isArray(object), 'setIn: "-" in path must correspond to array.')


### PR DESCRIPTION
An prototype-pollution attack was still possible with the previous fix for CVE-2022-25354.  
The method would crash, but the attack was still successful. 

PoC: 
```JavaScript
let obj = { foo: { bar: 'baz' } }
try {
  obj = setIn(obj, ['__proto__', 'polluted'], 'success');
} catch (e) {
  console.error(e);
}
console.log(({}).polluted);
```